### PR TITLE
Introducing CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "start:local": "npm start -- --env-path ./default.env",
     "test": "npm run lint && npm run unit && npm run checkonly",
     "update-docker-version": "sed -i.bck \"s|version=\\\"[0-9]*\\.[0-9]*\\.[0-9]*.*\\\"|version=\\\"${npm_package_version}\\\"|\" Dockerfile",
+    "update-changelog": "node ./scripts/update-changelog.js ${npm_package_version}",
     "unit": "tap -b tests/*.test.js",
-    "version": "npm run update-docker-version && rm -fr Dockerfile.bck && git add Dockerfile"
+    "version": "npm run update-changelog && npm run update-docker-version && rm -fr Dockerfile.bck && git add CHANGELOG.md Dockerfile"
   },
   "dependencies": {
     "@mia-platform/custom-plugin-lib": "^1.1.1"

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { join } = require('path')
+const { readFileSync, writeFileSync } = require('fs')
+
+function getISODateStringFrom(aJSDate) {
+  return aJSDate
+  .toISOString()
+  .split('T')
+  .shift()
+}
+
+function getNewContentForCHANGELOG({ aSemVerString, anISODateString }) {
+  return `[Unreleased]\n\n## [${aSemVerString}] ${anISODateString}`
+}
+
+const CHANGELOG_PATH = join(__dirname, '../CHANGELOG.md')
+
+let changelog = readFileSync(CHANGELOG_PATH, { encoding: 'utf-8' })
+
+changelog = changelog.replace('[Unreleased]', getNewContentForCHANGELOG({
+  aSemVerString: process.argv[2],
+  anISODateString: getISODateStringFrom(new Date()),
+}))
+
+writeFileSync(CHANGELOG_PATH, changelog)


### PR DESCRIPTION
- [x] introduced CHANGELOG.md
- [x] introduce simple script `update-changelog` which is called upon `npm version` and updates `CHANGELOG.md` according with the best practice.
- [ ] shall I add documentation about how to keep a `CHANGELOG.md` in the `README.md`? This is already documented at the top of the `CHANGELOG.md`
